### PR TITLE
Fixes to get code running

### DIFF
--- a/ead/getextents.py
+++ b/ead/getextents.py
@@ -1,5 +1,4 @@
 # import what we need
-import lxml
 from lxml import etree
 import csv
 import os
@@ -29,22 +28,19 @@ def getextents(xpath):
     for filename in os.listdir(ead_path):
         tree = etree.parse(join(ead_path, filename))
         # keep up with where we are
-        print "Processing ", filename
+        print("Processing " + filename)
         # parse and go through all component extents
         extents = tree.xpath(xpath)
-        for i in extents:
+        for extent in extents:
             # identify blank extents
-            extent = i.text
-            extent_path = tree.getpath(i)
+            extent_text = extent.text
+            extent_path = tree.getpath(extent)
             with open(output_csv, 'ab') as csvfile:
                 writer = csv.writer(csvfile, dialect='excel')
                 try:
-                    writer.writerow([filename, extent_path, extent])
+                    writer.writerow([filename, extent_path, extent_text])
                 except:
                     writer.writerow([filename, extent_path, 'ISSUE EXTENT'])
-
-# close the csv
-csvfile.close()
                 
 # get extents       
 getextents(all_extents) # <-- you'll have to change this to get the extents you want, "top level," component level or all (i want all)


### PR DESCRIPTION
Some edits:
- tree.getpath(i) was failing due to i being set to a string instead of an etree object in the previous line. After fixing this issue I also renamed instances of i to "extent" to be more semantic
- the "with" statement closes the csv automatically; having the separate csvfile.close() line leads to a crash
- Python 3 compatibility (enclosing print statements in parens)
- Since etree is the only lxml function that is used, we can remove the full lxml import
