### PR TITLE
fix for encoding errors

### DIFF
--- a/ead/getextents.py
+++ b/ead/getextents.py
@@ -33,14 +33,11 @@ def getextents(xpath):
         extents = tree.xpath(xpath)
         for extent in extents:
             # identify blank extents
-            extent_text = extent.text
+            extent_text = extent.text.encode("utf-8") if extent.text else ""
             extent_path = tree.getpath(extent)
             with open(output_csv, 'ab') as csvfile:
                 writer = csv.writer(csvfile, dialect='excel')
-                try:
-                    writer.writerow([filename, extent_path, extent_text])
-                except:
-                    writer.writerow([filename, extent_path, 'ISSUE EXTENT'])
+                writer.writerow([filename, extent_path, extent_text])
                 
 # get extents       
 getextents(all_extents) # <-- you'll have to change this to get the extents you want, "top level," component level or all (i want all)


### PR DESCRIPTION
This fixes encoding errors when trying to write extent text with non-ascii characters (namely "½"). We can also get rid of the try/except statement, since writing doesn't fail anymore.
