### PR TITLE
getname edits

### DIFF
--- a/ead/viaf/getname.py
+++ b/ead/viaf/getname.py
@@ -19,27 +19,27 @@ tag_names = ["persname", "corpname", "geogname", "genreform"]
 # initializes the dictionary we'll use to hold the tag names
 controlaccess_term_dictionary = {}
 for tag in tag_names:
-	controlaccess_term_dictionary[tag] = []
+    controlaccess_term_dictionary[tag] = []
 
 # xpath to where in the ead document we'll be looking for the given tag names
 controlaccess_xpath = '//controlaccess/*'
 
 # go through the files
 for filename in tqdm(os.listdir(ead_path)):
-	# only look at xml files
-	if filename.endswith(".xml"):
-		# create lxml etree version of ead document
-		ead_tree = ET.parse(path.join(ead_path, filename))
+    # only look at xml files
+    if filename.endswith(".xml"):
+        # create lxml etree version of ead document
+        ead_tree = ET.parse(path.join(ead_path, filename))
 
-		# go through the ead and grab all the text appearing in the tag types defined above
-		for sub in ead_tree.xpath(controlaccess_xpath):
-			for tag in tag_names:
-			    # we don't want to grab compound subject terms or empty strings
-				if tag in sub.tag and sub.text is not None and "--" not in sub.text:
-					controlaccess_term_dictionary[tag].append(sub.text.strip())
+        # go through the ead and grab all the text appearing in the tag types defined above
+        for sub in ead_tree.xpath(controlaccess_xpath):
+            for tag in tag_names:
+                # we don't want to grab compound subject terms or empty strings
+                if tag in sub.tag and sub.text is not None and "--" not in sub.text:
+                    controlaccess_term_dictionary[tag].append(sub.text.strip())
 
 # write all the names to a file - one file for each tag type
 for tag_type, names in controlaccess_term_dictionary.items():
-	with open(tag_type + ".txt", mode="w") as text_file:
-		for name in names:
-			text_file.write(name.encode("utf-8") + '\n')
+    with open(tag_type + ".txt", mode="w") as text_file:
+        for name in names:
+            text_file.write(name.encode("utf-8") + '\n')

--- a/ead/viaf/getname.py
+++ b/ead/viaf/getname.py
@@ -16,7 +16,7 @@ ead_path = 'path/to/eads'
 # tag names - set these to the tag types you want to capture the values of
 tag_names = ["persname", "corpname", "geogname", "genreform"]
 
-# initialize the dictionary we'll use to hold the tag names
+# initializes the dictionary we'll use to hold the tag names
 controlaccess_term_dictionary = {}
 for tag in tag_names:
 	controlaccess_term_dictionary[tag] = []


### PR DESCRIPTION
Changes:
- Removed code duplication by using a dictionary to hold and control the data
- Allows for an arbitrary number of tag names -- now all you have to do is add new entries to the initial tag_name list, and the code handles the rest (creating new dictionary keys, writing results for each tag name to its own file, etc.)
- Uses tqdm for tracking progress
- Uses .endswith(".xml") instead of regex
- Also can now run in python 3

The biggest question-mark to me is whether to include tqdm, since it adds an extra third-party dependency outside of lxml that folks would have to install. But it's so handy...

Happy to make changes if anything doesn't make sense.
